### PR TITLE
add task name with uniqueness

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.linting.enabled": false
+}

--- a/carrot/api.py
+++ b/carrot/api.py
@@ -162,7 +162,7 @@ class ScheduledTaskSerializer(serializers.ModelSerializer):
         model = ScheduledTask
         fields = (
             'task', 'interval_display', 'active', 'id', 'queue', 'exchange', 'routing_key', 'interval_type',
-            'interval_count', 'content', 'task_args',
+            'interval_count', 'content', 'task_args', 'task_name'
         )
         extra_kwargs = {
             'queue': {

--- a/carrot/api.py
+++ b/carrot/api.py
@@ -123,7 +123,6 @@ class ScheduledTaskSerializer(serializers.ModelSerializer):
                     functions = [o[0] for o in getmembers(mod) if isfunction(o[1]) and not o[0] == 'task']
 
                     for function in functions:
-                        print(function)
                         if function not in ['create_scheduled_task']:
                             f = '%s.%s' % (module, function)
                             task_choices.append(f)
@@ -213,8 +212,9 @@ class ScheduledTaskViewset(viewsets.ModelViewSet):
                     functions = [o[0] for o in getmembers(mod) if isfunction(o[1]) and not o[0] == 'task']
 
                     for function in functions:
-                        f = '%s.%s' % (module, function)
-                        task_choices.append(f)
+                        if function not in ['create_scheduled_task']:
+                            f = '%s.%s' % (module, function)
+                            task_choices.append(f)
                 except (ImportError, AttributeError):
                     pass
 

--- a/carrot/api.py
+++ b/carrot/api.py
@@ -123,7 +123,7 @@ class ScheduledTaskSerializer(serializers.ModelSerializer):
                     functions = [o[0] for o in getmembers(mod) if isfunction(o[1]) and not o[0] == 'task']
 
                     for function in functions:
-                        if function not in ['create_scheduled_task']:
+                        if "create_scheduled_task" not in function:
                             f = '%s.%s' % (module, function)
                             task_choices.append(f)
                 except (ImportError, AttributeError):
@@ -212,7 +212,7 @@ class ScheduledTaskViewset(viewsets.ModelViewSet):
                     functions = [o[0] for o in getmembers(mod) if isfunction(o[1]) and not o[0] == 'task']
 
                     for function in functions:
-                        if function not in ['create_scheduled_task']:
+                        if "create_scheduled_task" not in function:
                             f = '%s.%s' % (module, function)
                             task_choices.append(f)
                 except (ImportError, AttributeError):

--- a/carrot/api.py
+++ b/carrot/api.py
@@ -123,8 +123,9 @@ class ScheduledTaskSerializer(serializers.ModelSerializer):
                     functions = [o[0] for o in getmembers(mod) if isfunction(o[1]) and not o[0] == 'task']
 
                     for function in functions:
-                        f = '%s.%s' % (module, function)
-                        task_choices.append(f)
+                        if function not in ['create_scheduled_task']:
+                            f = '%s.%s' % (module, function)
+                            task_choices.append(f)
                 except (ImportError, AttributeError):
                     pass
             print(task_choices, value)

--- a/carrot/api.py
+++ b/carrot/api.py
@@ -123,6 +123,7 @@ class ScheduledTaskSerializer(serializers.ModelSerializer):
                     functions = [o[0] for o in getmembers(mod) if isfunction(o[1]) and not o[0] == 'task']
 
                     for function in functions:
+                        print(function)
                         if function not in ['create_scheduled_task']:
                             f = '%s.%s' % (module, function)
                             task_choices.append(f)

--- a/carrot/models.py
+++ b/carrot/models.py
@@ -123,7 +123,7 @@ class ScheduledTask(models.Model):
     task = models.CharField(max_length=200)
     task_args = models.TextField(null=True, blank=True, verbose_name='Positional arguments')
     content = models.TextField(null=True, blank=True, verbose_name='Keyword arguments')
-
+    task_name = models.CharField(max_length=200, unique=True) #: task name with uniqueness
     active = models.BooleanField(default=True)
 
     def get_absolute_url(self):

--- a/carrot/models.py
+++ b/carrot/models.py
@@ -49,6 +49,7 @@ class MessageLog(models.Model):
     task = models.CharField(max_length=200)#: the import path for the task to be executed
     task_args = models.TextField(null=True, blank=True, verbose_name='Task positional arguments')
     content = models.TextField(null=True, blank=True, verbose_name='Task keyword arguments')
+    task_name = models.CharField(max_length=200, unique=True) #: task name with uniqueness
 
     exception = models.TextField(null=True, blank=True)
     traceback = models.TextField(null=True, blank=True)

--- a/carrot/models.py
+++ b/carrot/models.py
@@ -49,7 +49,7 @@ class MessageLog(models.Model):
     task = models.CharField(max_length=200)#: the import path for the task to be executed
     task_args = models.TextField(null=True, blank=True, verbose_name='Task positional arguments')
     content = models.TextField(null=True, blank=True, verbose_name='Task keyword arguments')
-    task_name = models.CharField(max_length=200, unique=True) #: task name with uniqueness
+   
 
     exception = models.TextField(null=True, blank=True)
     traceback = models.TextField(null=True, blank=True)

--- a/carrot/templates/carrot/index.vue
+++ b/carrot/templates/carrot/index.vue
@@ -765,6 +765,11 @@
           } else {
             return [
               {
+                text: 'Task Name',
+                value: 'task_name',
+                align: 'left',
+              }, {
+              {
                 text: 'Task',
                 value: 'task',
                 align: 'left',

--- a/carrot/templates/carrot/index.vue
+++ b/carrot/templates/carrot/index.vue
@@ -304,6 +304,7 @@
                         <td>[{ props.item.content | cropped }]</td>
                       </tr>
                       <tr v-else @click="selectedScheduledTask = props.item">
+                          <td>[{ props.item.task_name }]</td>
                           <td>[{ props.item.task }]</td>
                           <td>Every [{ props.item.interval_count }] [{ props.item.interval_type }]</td>
                           <td><v-icon v-if="props.item.active">check</v-icon><v-icon v-else>close</v-icon></td>
@@ -542,6 +543,7 @@
             this.selectedScheduledTask = {
                 id: null,
                 task: null,
+                task_name: null,
                 task_args: null,
                 content: null,
                 queue: null,

--- a/carrot/templates/carrot/index.vue
+++ b/carrot/templates/carrot/index.vue
@@ -769,7 +769,6 @@
                 value: 'task_name',
                 align: 'left',
               }, {
-              {
                 text: 'Task',
                 value: 'task',
                 align: 'left',

--- a/carrot/utilities.py
+++ b/carrot/utilities.py
@@ -140,7 +140,7 @@ def publish_message(task, *task_args, priority=0, queue=None, exchange='', routi
     return msg.publish()
 
 
-def create_scheduled_task(task, interval, queue=None, **kwargs):
+def create_scheduled_task(task, interval, task_name, queue=None, **kwargs):
     """
     Helper function for creating a :class:`carrot.models.ScheduledTask`
 
@@ -169,6 +169,7 @@ def create_scheduled_task(task, interval, queue=None, **kwargs):
         interval_count=count,
         routing_key=queue,
         task=task,
+        task_name=task_name,
         content=json.dumps(kwargs or '{}'),
     )
     return t


### PR DESCRIPTION
Hello,

I just test your module in replacement of django-q with creating scheduled tasks programatically. 
I used a previous script used with django-q : my tasks were scheduled several times. 

Django-Q take care of uniqueness, feature not available here. I tried to solve this with this code.

If you find this interesting, let's pull it :-).

Thanks for your saving time works.

Regards,

Thierry