### PR TITLE
Add carrot_send as a management command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 dist/
 django_carrot.egg-info/
 docs/build/
+**/__pycache__/

--- a/carrot/management/commands/carrot_send.py
+++ b/carrot/management/commands/carrot_send.py
@@ -1,0 +1,21 @@
+import json
+import pprint
+from django.core.management.base import BaseCommand, CommandError
+from carrot.utilities import publish_message
+
+
+class Command(BaseCommand):
+    help = 'Queues a job for execution'
+
+    def add_arguments(self, parser):
+        parser.add_argument('job_name', type=str)
+        parser.add_argument('job_args', type=str, nargs='+')
+
+    def handle(self, *args, **options):
+        job_name = options['job_name']
+        job_args = options['job_args']
+
+        if job_args:
+            publish_message(job_name, *job_args)
+        else:
+            publish_message(job_name)


### PR DESCRIPTION
This new command can accept args (as strings) but no kwargs.  I did some work to see if I could handle them, and it was a mess.  Personally I think this goes a fair amount of the way towards making it easier to trigger jobs, and if you need to be able to pass an int or a bool you can make a wrapper function that does the necessary parsing and then calls the "real" command.