### PR TITLE
Improve windows compatibility

### DIFF
--- a/carrot/management/commands/carrot.py
+++ b/carrot/management/commands/carrot.py
@@ -106,8 +106,12 @@ class Command(BaseCommand):
         for q in psutil.process_iter():
             if 'python' in q.name():
                 if len(q.cmdline()) > 1 and 'manage.py' in q.cmdline()[1] and 'carrot' in q.cmdline()[2]:
-                    if not q._pid == os.getpgid(0):
-                        running_pids.append(q._pid)
+                    if os.name == 'nt':
+                        if not q._pid == os.getpid():
+                            running_pids.append(q._pid)
+                    else:
+                        if not q._pid == os.getpgid(0):
+                            running_pids.append(q._pid)
 
         if running_pids:
             self.stdout.write(

--- a/carrot/management/commands/carrot_daemon.py
+++ b/carrot/management/commands/carrot_daemon.py
@@ -116,7 +116,7 @@ class Command(BaseCommand):
         if kwargs:
             self.options = kwargs
 
-        options: list = ['python3', 'manage.py', 'carrot', '--verbosity', str(kwargs.get('verbosity', 2)),
+        options: list = [sys.executable, sys.argv[0], 'carrot', '--verbosity', str(kwargs.get('verbosity', 2)),
                          '--logfile', self.options['logfile'], '--loglevel', self.options['loglevel']]
 
         if not self.options['run_scheduler']:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-carrot"
-version = "1.4.4a0"
+version = "1.5.0"
 description = "A RabbitMQ asynchronous task queue for Django."
 authors = ["Christoper Davies <christopherdavies553@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Fixes two issue when trying to run this on Windows.

Please review, since I am not fully sure is `os.getpgid(0)` can simply be replace with `os.getpid()`.

It does seem to get the right result though (and the current version does not run at all, so it should certainly be an improvement.